### PR TITLE
Change table caption to bottom

### DIFF
--- a/resources/themes/riscv-pdf.yml
+++ b/resources/themes/riscv-pdf.yml
@@ -226,6 +226,7 @@ table:
   border_color: dddddd
   border_width: $base_border_width
   cell_padding: 3
+  caption_side: bottom
 toc:
   indent: $horizontal_rhythm
   line_height: 1.4


### PR DESCRIPTION
During the psABI review, @cmuellner suggest the table caption put on the bottom is more common, so I think this change should go back to this template.

https://github.com/riscv-non-isa/riscv-elf-psabi-doc/pull/227#issuecomment-958147327