### PR TITLE
Use ghcr.io/riscv/riscv-docs-base-container-image:latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 DATE ?= $(shell date +%Y-%m-%d)
 DOCKER_RUN := docker run --rm -v ${PWD}:/build -w /build \
-riscvintl/riscv-docs-base-container-image:latest
+ghcr.io/riscv/riscv-docs-base-container-image:latest
 
 # DO NOT SPECIFY A VERSION OR REVMARK HERE! The revision version and mark
 # (draft/release/etc) should be marked via the :revnumber: and :revremark: fields


### PR DESCRIPTION
This updates the docs container image reference in the root Makefile.

The old `riscvintl` image has been replaced with the `ghcr.io/riscv` image.
